### PR TITLE
Feature: add camelCaseSvgKeywords to stylelint value-keyword-case

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -30,6 +30,12 @@
     "no-duplicate-selectors": null,
     "max-line-length": null,
     "scss/double-slash-comment-whitespace-inside": null,
-    "font-family-name-quotes": null
+    "font-family-name-quotes": null,
+    "value-keyword-case": [
+      "lower",
+      {
+        "camelCaseSvgKeywords": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
### Summary of Changes 📋
Adds `value-keyword-case` configuration to `stylelint.json`  to allow for camel casing svg keywords such as `currentColor`. Change is based on this [discussion.](https://github.com/stylelint/stylelint/issues/5863)


