### PR TITLE
updating allure patch version to resolve critical alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1351,24 +1351,31 @@
       }
     },
     "@shelex/allure-js-commons-browser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@shelex/allure-js-commons-browser/-/allure-js-commons-browser-1.4.1.tgz",
-      "integrity": "sha512-8cImusrmhPU4Ic9IT2416sg6dnxKgjE3ftCdnebU5WlLsEhEQ7Iz1i80jJeIyJAz3mDO5eXFkNmFFS7rll6VFA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@shelex/allure-js-commons-browser/-/allure-js-commons-browser-1.5.0.tgz",
+      "integrity": "sha512-IBZcmHTXpyfPmZgpasc4PmxAOuk+GTqxUUntmPKVU0zeauGysluFt+hJ5pPV22TLxEeKgeyl63p6ic6P3usDtg==",
       "requires": {
-        "uuid": "9.0.0"
+        "uuid": "9.0.1"
       }
     },
     "@shelex/cypress-allure-plugin": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@shelex/cypress-allure-plugin/-/cypress-allure-plugin-2.40.0.tgz",
-      "integrity": "sha512-/WEd51ggYscxjQgQpgEvW33zkqUc6FIMct2SM12mAxqiiKtXNXc0isX5eTNbmrttWCypgTHKJFsRtc3vfMemPw==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@shelex/cypress-allure-plugin/-/cypress-allure-plugin-2.40.1.tgz",
+      "integrity": "sha512-+PV3v/+Yj+Ppm5hDi17JehFPwCgAr66mCbtfMtqScihNvB5A4xPG8MgXiAE52pdeHCJDPy9BF83bPMgd6YyCnA==",
       "requires": {
-        "@shelex/allure-js-commons-browser": "1.4.1",
-        "crypto-js": "4.1.1",
+        "@shelex/allure-js-commons-browser": "1.5.0",
+        "crypto-js": "4.2.0",
         "debug": "4.3.4",
-        "object-inspect": "1.12.3",
+        "object-inspect": "1.13.1",
         "path-browserify": "1.0.1",
-        "uuid": "9.0.0"
+        "uuid": "9.0.1"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+          "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+        }
       }
     },
     "@types/eslint": {
@@ -2185,9 +2192,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "css-functions-list": {
       "version": "3.2.1",
@@ -5825,9 +5832,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/eslint-parser": "^7.22.15",
     "@babel/preset-env": "^7.23.2",
     "@cypress/webpack-preprocessor": "^5.17.1",
-    "@shelex/cypress-allure-plugin": "^2.40.0",
+    "@shelex/cypress-allure-plugin": "^2.40.1",
     "cypress": "12.14.0",
     "cypress-real-events": "^1.10.3",
     "eslint": "^8.51.0",


### PR DESCRIPTION
### Summary of Changes 📋

<!-- summarize & list your changes here -->
allure package deps were updated from 2.40.0 to 2.40.1 to fix the critical security alert. See issue [here](https://github.com/Shelex/cypress-allure-plugin/issues/224).
So updating patch version in this pr for this package. 