### PR TITLE
Feature/drop support node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18, 20 ]
+        node: [ 18, 20 ]
 
     name: Node ${{ matrix.node }} sample
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18, 20 ]
+        node: [ 18, 20 ]
 
     name: Node ${{ matrix.node }} sample
     steps:

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: 'airbnb',
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2021,
     sourceType: 'module',
     requireConfigFile: false,
     ecmaFeatures: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "stylelint-config-standard-scss": "^11.1.0",
         "webpack": "^5.89.0"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      },
       "peerDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^18.0.6",
         "@cypress/webpack-preprocessor": "^5.17.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "1.0.6",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "bugs": {
     "url": "https://github.com/HubSpotWebTeam/wt-eslint-browser/issues"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "homepage": "https://github.com/HubSpotWebTeam/wt-eslint-browser#readme",
   "author": "Marketing Web Team",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

- BREAKING: set babel parser ECMA version to 2021
- BREAKING: removed support for Node 16, from this version only 18 and above are supported

