### PR TITLE
Remove deprecated stylelint rules

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,7 +17,6 @@
     }],
     "scss/dollar-variable-pattern": null,
     "scss/at-import-no-partial-leading-underscore": null,
-    "string-quotes": null,
     "selector-class-pattern": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "scss/at-import-partial-extension": null,
@@ -28,7 +27,6 @@
     "scss/dollar-variable-empty-line-before": null,
     "shorthand-property-no-redundant-values": null,
     "no-duplicate-selectors": null,
-    "max-line-length": null,
     "scss/double-slash-comment-whitespace-inside": null,
     "font-family-name-quotes": null,
     "value-keyword-case": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

- Remove stylistic rules which were [deprecated in stylelint v15](https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules) and now [completely removed in stylelint v16](https://stylelint.io/migration-guide/to-16#removed-deprecated-stylistic-rules) (breaking stylelint runs)
  - `string-quotes`
  - `max-line-length`

![missing-deprecated-stylelint-rules](https://github.com/HubSpotWebTeam/wt-eslint-browser/assets/1349608/bf7ba99f-5b87-441c-9414-1413678a38b2)