### PR TITLE
Sets media-feature-range-notation to warn

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -33,6 +33,12 @@
     "no-duplicate-selectors": null,
     "scss/double-slash-comment-whitespace-inside": null,
     "font-family-name-quotes": null,
+    "media-feature-range-notation": [
+      "context",
+      {
+        "severity": "warning"
+      }
+    ],
     "value-keyword-case": [
       "lower",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

- fix: Sets the `media-feature-range-notation` rule  to produce a warning instead of an error. This is temporary and will be removed at a later date (tbd).