### PR TITLE
Bugfix/fix issue with devbase url config

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -18,7 +18,7 @@ const envs = {
 };
 
 /**
- * Recursively climbs up the filepath, until it finds what directory the 
+ * Recursively climbs up the filepath, until it finds what directory the
  * 'hubspot.config.yml' file is stored in.
  * @param {string} currDir - the current working directory path to search from
  * @returns {string} The absolute path of the project's root directory
@@ -77,7 +77,7 @@ async function setupNodeEvents(on, config) {
           ],
         },
       },
-    })
+    }),
   );
   allureWriter(on, config);
   // Make sure to return the config object as it might have been modified by the plugin.
@@ -119,4 +119,4 @@ module.exports = {
   config,
   envs,
   getDevBaseUrl,
-}
+};

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -18,8 +18,9 @@ const envs = {
 };
 
 /**
- * Recursively climbs up the filepath, until it finds what directory the
- * 'hubspot.config.yml' file is stored in.
+ * @description Recursively climbs up the filepath, until it finds what directory
+ * the directory where the hubspot.config.yml file is located.
+ *
  * @param {string} currDir - the current working directory path to search from
  * @returns {string} The absolute path of the project's root directory
  */

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,8 +6,8 @@ const allureWriter = require('@shelex/cypress-allure-plugin/writer');
 const webpack = require('@cypress/webpack-preprocessor');
 
 const { ENV } = process.env;
-const DEV = 'dev';
-const QA = 'qa';
+const DEV = 'DEV';
+const QA = 'QA';
 const PROD = 'prod';
 const currentEnv = ENV || QA;
 
@@ -19,13 +19,14 @@ const envs = {
 }
 
 /**
+ * @param {string} ENV The environment that the user sets in their env file, defaults to DEV
  * @returns {string|null} The `baseUrl` set for the `DEV` portal in `hubspot.config.yml`
  *   or `null` if this is not the dev environment or no such property exists.
  */
-const getDevBaseUrl = () => {
-  if (ENV === DEV) {
+const getDevBaseUrl = (ENV) => {
+  if (ENV.toLowerCase() === DEV.toLowerCase()) {
     try {
-      const configPath = path.resolve(__dirname, 'hubspot.config.yml');
+      const configPath = path.resolve('./', 'hubspot.config.yml');
       const config = fs.readFileSync(configPath, 'utf8');
       const { portals } = yaml.load(config);
       const devPortal = portals.find(portal => portal.name === 'DEV');

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -15,10 +15,10 @@ const envs = {
   DEV,
   QA,
   PROD,
-}
+};
 
 /**
- * 
+ *
  * @param {string} currDir - the current working directory path to search from
  * @returns {string} The absolute path of the project's root directory
  */
@@ -27,7 +27,7 @@ const getRootDir = (currDir) => {
   const parentDir = path.dirname(currDir);
   if (parentDir === currDir) global.console.error('Error: Could not find the hubspot.config.yml file within the projects directories.');
   return getRootDir(parentDir);
-}
+};
 
 /**
  * @returns {string|null} The `baseUrl` set for the `DEV` portal in `hubspot.config.yml`
@@ -35,20 +35,21 @@ const getRootDir = (currDir) => {
  */
 const getDevBaseUrl = () => {
   try {
+    global.console.log(
+      'To test a dev URL, add the `baseUrl` property to your `DEV` portal configuration in `hubspot.config.yml`',
+    );
+    
     const root = getRootDir(__dirname);
     const configPath = path.resolve(root, 'hubspot.config.yml');
     const config = fs.readFileSync(configPath, 'utf8');
     const { portals } = yaml.load(config);
     const devPortal = portals.find(portal => portal.name === 'DEV');
     const devBaseUrl = devPortal.baseUrl;
-    return devBaseUrl ? devBaseUrl : null;
+    return devBaseUrl || null;
   } catch (error) {
     global.console.error(error);
+    return null;
   }
-
-  global.console.log(
-    'To test a dev URL, add the `baseUrl` property to your `DEV` portal configuration in `hubspot.config.yml`',
-  );
 };
 
 const e2e = {
@@ -77,7 +78,7 @@ const e2e = {
     await addCucumberPreprocessorPlugin(on, config);
     on('file:preprocessor', webpack(webpackOptions));
     allureWriter(on, config);
-    return config
+    return config;
   },
 };
 
@@ -111,4 +112,4 @@ module.exports = {
   config,
   envs,
   getDevBaseUrl,
-}
+};

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -18,7 +18,8 @@ const envs = {
 };
 
 /**
- *
+ * Recursively climbs up the filepath, until it finds what directory the 
+ * 'hubspot.config.yml' file is stored in.
  * @param {string} currDir - the current working directory path to search from
  * @returns {string} The absolute path of the project's root directory
  */


### PR DESCRIPTION
### Summary of Changes 📋
Fixes an issue that occurred when porting these configs to the library, as opposed to storing in their project folders.

Background:
The goal of porting the configs was to make setup way easier, we hadn't considered the possible scope issues we would encounter with the different project setups. Since then we've seen issues when:
- Projects are not at the root (ie: client/server has it's own node_modules)
- Projects are unable to access their `process.env` files
- Projects don't currently use a process.env file.

This change does 2 things
- Adds a utility function to recursively get the PROJECT root directory. This is because the file `hubspot.config.yml` will be there, we don't place those files in client/server/ or other sub folders. If the file can't be found while climbing the directories, we will pass a console.error.
- Removes the conditionals and need for a passed param in getDevBaseURL, since the function itself will always be inherently getting the DEV URL from hubspot.config.yml

An example of using this file, would be something like this:
```javascript
import { getDevBaseUrl, config, envs } from '@hs-web-team/eslint-config-browser/cypress.config.js';
const baseUrls = {
  [envs.DEV]: getDevBaseUrl(),
  [envs.QA]: 'https://www.wthubspot.com',
  [envs.PROD]: 'https://www.hubspot.com',
};

/* baseUrls
{
  DEV: 'https://www.hubspot.com',
  QA: 'https://blog.wthubspot.com',
  PROD: 'https://blog.hubspot.com',
}
*/
```

@swatinigam and I tested this change on both projects that live in their root directory (blog) and projects with subdirectories (resource-center). From what we can tell, they work the same, as the recursive function only climbs to the root.

JIRA: https://issues.hubspotcentral.com/browse/FDNDEVOPS-3346