### PR TITLE
Change HTML setting for React self-closing-comp rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ module.exports = {
     'react/no-array-index-key': 0,
     'react/destructuring-assignment': 0,
     'react/require-default-props': 0,
+    'react/self-closing-comp': [2, {
+      component: true,
+      html: false,
+    }],
   },
   globals: {
     $: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

Update the `react/self-closing-comp` rule ([docs](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md)) to error for React components, but to not error for HTML components, in line with Web Team coding standards.