### PR TITLE
Disable import/prefer-default-export rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'arrow-parens': 0,
     'import/extensions': ['warn', 'ignorePackages'],
     'import/no-unresolved': 'off',
+    'import/prefer-default-export': 'off',
     'no-plusplus': 0,
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'no-confusing-arrow': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

- disable [the `import/prefer-default-export` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md), as precursor to eventually enabling [the `import/no-default-export` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md)

