### PR TITLE
Cypress config- renaming cypress environments to lower case

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,15 +6,15 @@ const allureWriter = require('@shelex/cypress-allure-plugin/writer');
 const webpack = require('@cypress/webpack-preprocessor');
 
 const DEV = 'DEV';
-const qa = 'qa';
-const prod = 'prod';
-const currentEnv = qa;
+const QA = 'qa';
+const PROD = 'prod';
+const currentEnv = QA;
 
 const envs = {
   currentEnv,
   DEV,
-  qa,
-  prod,
+  QA,
+  PROD,
 };
 
 /**

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,15 +6,15 @@ const allureWriter = require('@shelex/cypress-allure-plugin/writer');
 const webpack = require('@cypress/webpack-preprocessor');
 
 const DEV = 'DEV';
-const QA = 'QA';
-const PROD = 'prod';
-const currentEnv = QA;
+const qa = 'qa';
+const prod = 'prod';
+const currentEnv = qa;
 
 const envs = {
   currentEnv,
   DEV,
-  QA,
-  PROD,
+  qa,
+  prod,
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary of Changes 📋

Changing QA and Prod environments to qa and prod respectively, for consistency with JSL's environment naming. Leaving DEV env as it is to avoid issues in hubspot.config.yml.


