### PR TITLE
added typescript loader for cypress webpack

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -40,7 +40,7 @@ const getDevBaseUrl = () => {
     global.console.log(
       'To test a dev URL, add the `baseUrl` property to your `DEV` portal configuration in `hubspot.config.yml`',
     );
-    
+
     const root = getRootDir(__dirname);
     const configPath = path.resolve(root, 'hubspot.config.yml');
     const config = fs.readFileSync(configPath, 'utf8');
@@ -55,7 +55,7 @@ const getDevBaseUrl = () => {
 };
 
 /**
- * @description Get the baseUrls for different environments from the ci config file for local test execution. 
+ * @description Get the baseUrls for different environments from the ci config file for local test execution.
  * @returns {object} baseUrls - The base urls object
  */
 const getBaseUrls = () => {
@@ -96,6 +96,15 @@ async function setupNodeEvents(on, config) {
         },
         module: {
           rules: [
+            {
+              test: /\.ts$/,
+              exclude: [/node_modules/],
+              use: [
+                {
+                  loader: 'ts-loader',
+                },
+              ],
+            },
             {
               test: /\.feature$/,
               use: [


### PR DESCRIPTION
### Summary of Changes 📋

- added loader for typescript, currently this config will pick up `.ts` files but will throw an error:


```bash
Module parse failed: Unexpected token (15:46)
You may need an appropriate loader to handle this file type,
currently no loaders are configured to process this file.
See https://webpack.js.org/concepts#loaders
```