### PR TITLE
fix(getRootDir): prevent infinite loop when hubspot.config.yml is missing

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,7 +27,7 @@ const getRootDir = currDir => {
   if (fs.existsSync(path.join(currDir, 'hubspot.config.yml'))) return currDir;
   const parentDir = path.dirname(currDir);
   if (parentDir === currDir) {
-    global.console.error('Error: Could not find the hubspot.config.yml file within the projects directories.');
+    throw new Error('Error: Could not find the hubspot.config.yml file within the projects directories.');
   }
   return getRootDir(parentDir);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hs-web-team/eslint-config-browser",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs-web-team/eslint-config-browser",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "HubSpot Marketing WebTeam ESLint rules for Browsers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In certain cases, getRootDir() would recurse infinitely if the config file was not found. This patch adds a termination condition at the root directory.

Our e2e suite doesn't rely on a config file and the logs were spammed with thousands of errors.

### Summary of Changes 📋

```
> require('./cypress.config.js').getRootDir(process.cwd())
```

Before (truncated)
```
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Error: Could not find the hubspot.config.yml file within the projects directories.
Uncaught RangeError: Maximum call stack size exceeded
    at console.value (node:internal/console/constructor:314:13)
    at console.error (node:internal/console/constructor:394:26)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:30:20)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:33:10)
```

After
```
Uncaught:
Error: Error: Could not find the hubspot.config.yml file within the projects directories.
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:30:11)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:32:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:32:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:32:10)
    at getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:32:10)
    at Object.getRootDir (/Users/cayre/Documents/Code/wt-eslint-browser/cypress.config.js:32:10)
```
